### PR TITLE
parsing timestamps from httpd logfile fixed

### DIFF
--- a/src/main/java/org/opencastproject/influxdbadapter/LogLine.java
+++ b/src/main/java/org/opencastproject/influxdbadapter/LogLine.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -49,7 +50,8 @@ public final class LogLine {
           "^(?<ip>(?:[0-9]{1,3}\\.){3}[0-9]{1,3}) - - \\[(?<date>[^]]+)] \"(?<request>[^\"]*)\" (?<httpret>[0-9]+) (?<unknown1>(?:[0-9]+|-)) \"(?<referrer>[^\"]*)\" \"(?<agent>[^\"]+)\"");
 
   // Example: 10/Feb/2019:03:38:22 +0100
-  private static final DateTimeFormatter LOG_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd/MMM/yyyy:HH:mm:ss Z");
+  private static final DateTimeFormatter LOG_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd/MMM/yyyy:HH:mm:ss Z")
+                                                                               .withLocale(Locale.ENGLISH);
 
   private final CharSequence origin;
   private final String ip;


### PR DESCRIPTION
On system with non english locale the date parser is unable to parse timestamps even though the date format string is correct. This issue happen, because the httpd timestamp contain an 3-digit month value in english. This patch force set the english locale on date time parser.