### PR TITLE
fixes possible null pointer exception

### DIFF
--- a/src/main/java/org/opencastproject/influxdbadapter/OpencastUtils.java
+++ b/src/main/java/org/opencastproject/influxdbadapter/OpencastUtils.java
@@ -51,11 +51,13 @@ public final class OpencastUtils {
   private static Optional<String> seriesForEventJson(final String eventJson) {
     try {
       final Map<String, Object> m = new Gson().fromJson(eventJson, Map.class);
-      final Object isPartOf = m.get("is_part_of");
-      if (!(isPartOf instanceof String)) {
-        return Optional.empty();
+      if (m != null) {
+        final Object isPartOf = m.get("is_part_of");
+        if (isPartOf instanceof String) {
+          return Optional.of((String) isPartOf);
+        }
       }
-      return Optional.of((String) isPartOf);
+      return Optional.empty();
     } catch (final JsonSyntaxException e) {
       throw new OurJsonSyntaxException(eventJson);
     }


### PR DESCRIPTION
I've see a lot of NPE in log output like this
```
13:45:27.370 [main] ERROR o.o.influxdbadapter.Main - Error:
java.lang.NullPointerException: null
        at org.opencastproject.influxdbadapter.OpencastUtils.seriesForEventJson(OpencastUtils.java:54)
        at io.reactivex.internal.operators.flowable.FlowableMap$MapSubscriber.onNext(FlowableMap.java:63)
        at io.reactivex.internal.operators.flowable.FlowableConcatMap$ConcatMapImmediate.innerNext(FlowableConcatMap.java:214)
        at io.reactivex.internal.operators.flowable.FlowableConcatMap$ConcatMapInner.onNext(FlowableConcatMap.java:587)
        at io.reactivex.internal.operators.flowable.FlowableConcatMap$WeakScalarSubscription.request(FlowableConcatMap.java:367)
        at io.reactivex.internal.subscriptions.SubscriptionArbiter.setSubscription(SubscriptionArbiter.java:99)
        at io.reactivex.internal.operators.flowable.FlowableConcatMap$ConcatMapImmediate.drain(FlowableConcatMap.java:335)
        at io.reactivex.internal.operators.flowable.FlowableConcatMap$BaseConcatMapSubscriber.onNext(FlowableConcatMap.java:159)
        at io.reactivex.internal.operators.flowable.FlowableConcatArray$ConcatArraySubscriber.onNext(FlowableConcatArray.java:77)
        at io.reactivex.internal.subscriptions.ScalarSubscription.request(ScalarSubscription.java:55)
        at io.reactivex.internal.subscriptions.SubscriptionArbiter.setSubscription(SubscriptionArbiter.java:99)
        at io.reactivex.internal.operators.flowable.FlowableConcatArray$ConcatArraySubscriber.onSubscribe(FlowableConcatArray.java:71)
…
```