### PR TITLE
REFACTOR Caching

### DIFF
--- a/docs/opencast-influxdb-adapter.properties
+++ b/docs/opencast-influxdb-adapter.properties
@@ -20,8 +20,11 @@ adapter.invalid-publication-channels=internal
 # opencast.external-api.uri=https://{organization}.api.opencast.com
 # opencast.external-api.user=admin
 # opencast.external-api.password=password
-# opencast.external-api.max-cache-size=1000
-# opencast.external-api.cache-expiration-duration=PT0M
+##Cache duration. When set to PT0M, cache is disabled. Min. Caching is one minute.
+# opencast.external-api.cache-expiration-duration=PT60M
+# opencast.external-api.cache-dir=/tmp/opencast-influxdb-adapter-cache
+## Max. size in MB
+# opencast.external-api.cache-size=50
 # Set this to true if every episode must have a series assigned to it in your Opencast setup.
 # In this case, a missing series is considered (and logged as) an error. Otherwise, it's just
 # a normal data point.

--- a/src/main/java/org/opencastproject/influxdbadapter/CacheInterceptor.java
+++ b/src/main/java/org/opencastproject/influxdbadapter/CacheInterceptor.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.influxdbadapter;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.CacheControl;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+/**
+ * Interceptor that forces a client side cache of maxAge minutes. 
+ * Ignores all pragmas and cache-control from server.
+ * 
+ *
+ */
+public class CacheInterceptor implements Interceptor {
+
+  private int maxAge;
+
+  public CacheInterceptor(int maxAge) {
+    this.maxAge = maxAge;
+  }
+
+  @Override
+  public Response intercept(Chain chain) throws IOException {
+      Response response = chain.proceed(chain.request());
+
+      CacheControl cacheControl = new CacheControl.Builder()
+              .maxAge(this.maxAge, TimeUnit.MINUTES)
+              .build();
+
+      return response.newBuilder()
+              .removeHeader("Pragma")
+              .removeHeader("Cache-Control")
+              .header("Cache-Control", cacheControl.toString())
+              .build();
+  }
+}

--- a/src/main/java/org/opencastproject/influxdbadapter/OpencastConfig.java
+++ b/src/main/java/org/opencastproject/influxdbadapter/OpencastConfig.java
@@ -21,6 +21,7 @@
 
 package org.opencastproject.influxdbadapter;
 
+import java.io.File;
 import java.time.Duration;
 
 /**
@@ -32,18 +33,25 @@ public final class OpencastConfig {
   private final String password;
   private final boolean seriesAreOptional;
   private final Duration cacheExpirationDuration;
+  private final long cacheSize;
+  private final File cacheDir;
 
   public OpencastConfig(
           final String uri,
           final String user,
           final String password,
           final boolean seriesAreOptional,
-          final Duration cacheExpirationDuration) {
+          final Duration cacheExpirationDuration,
+          final File cacheDir,
+          final long cacheSize
+          ) {
     this.uri = uri;
     this.user = user;
     this.password = password;
     this.seriesAreOptional = seriesAreOptional;
     this.cacheExpirationDuration = cacheExpirationDuration;
+    this.cacheDir = cacheDir;
+    this.cacheSize = cacheSize;
   }
 
   public String getUri() {
@@ -64,5 +72,13 @@ public final class OpencastConfig {
 
   public Duration getCacheExpirationDuration() {
     return this.cacheExpirationDuration;
+  }
+
+  public long getCacheSize() {
+    return cacheSize;
+  }
+
+  public File getCacheDir() {
+    return cacheDir;
   }
 }


### PR DESCRIPTION
This PR fixes #15.

Details:

Instead of caching in the Reactive Stream layer we use the caching facilities of `OkHttpClient`. The behaviour differs from the former implementation in

1) It caches :-) and does not double up page impressions
2) It caches on disk, not in memory, so there are parameter for the caching directory and size

```
##Cache duration. When set to PT0M, cache is disabled. Min. Caching is one minute.
opencast.external-api.cache-expiration-duration=PT60M
opencast.external-api.cache-dir=/tmp/opencast-influxdb-adapter-cache
## Max. size in MB
opencast.external-api.cache-size=50
```

3) Cache is persistent (restarting the application does not clear the cache). However clearing the cache is as easy as deleting the caching directory


