### PR TITLE
Configurable LogLine, RequestLine and DateTimeFormat

### DIFF
--- a/docs/opencast-influxdb-adapter.properties
+++ b/docs/opencast-influxdb-adapter.properties
@@ -2,11 +2,15 @@ influxdb.uri=http://localhost:8086
 influxdb.user=root
 influxdb.password=root
 influxdb.db-name=opencast
+# Can be "debug", "info" and "error"
 influxdb.log-level=info
 # Can be off by default, will use default RP
 # influxdb.retention-policy=infinite
 log-file=/var/log/httpd/access_log
-# Can be "debug", "info" and "error"
+# Can be off by default, will use default
+# adapter.httpd.logline-regex=^(?<ip>(?:[0-9]{1,3}\\.){3}[0-9]{1,3}) - (-|[^ ]+) \\[(?<date>[^]]+)\\] "(?<request>[^"]*)" (?<httpret>[0-9]+) (?<unknown1>(?:[0-9]+|-)) "(?<referrer>[^"]*)" "(?<agent>[^"]+)"
+# adapter.httpd.requestline-regex=^(?<method>[^ ]+) /(static/)?(?<organizationid>[^/]+)/(?<publicationchannel>[^/]+)/(?<episodeid>[^/]+)/(?<assetid>[^/]+)/[^/ ]+ .+$
+# adapter.httpd.datetime-format=dd/MMM/yyyy:HH:mm:ss Z
 adapter.view-interval-iso-duration=PT2H
 adapter.log-configuration-file=logback-sample.xml
 adapter.invalid-user-agents=Ruby,slurp,bot,spider,curl

--- a/src/main/java/org/opencastproject/influxdbadapter/ConfigurationException.java
+++ b/src/main/java/org/opencastproject/influxdbadapter/ConfigurationException.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.influxdbadapter;
+
+@SuppressWarnings("serial")
+public class ConfigurationException extends RuntimeException {
+
+  public ConfigurationException() {
+    super();
+  }
+
+  public ConfigurationException(String message, Throwable cause, boolean enableSuppression,
+          boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+  public ConfigurationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public ConfigurationException(String message) {
+    super(message);
+  }
+
+  public ConfigurationException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/src/main/java/org/opencastproject/influxdbadapter/LogLineConfiguration.java
+++ b/src/main/java/org/opencastproject/influxdbadapter/LogLineConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.influxdbadapter;
+
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Pattern;
+
+public class LogLineConfiguration {
+
+  public LogLineConfiguration(Pattern pattern, DateTimeFormatter dateTimeFormatter) {
+    super();
+    this.pattern = pattern;
+    this.dateTimeFormatter = dateTimeFormatter;
+  }
+
+  private Pattern pattern;
+  private DateTimeFormatter dateTimeFormatter;
+
+  public Pattern getPattern() {
+    return pattern;
+  }
+
+  public void setPattern(Pattern pattern) {
+    this.pattern = pattern;
+  }
+
+  public DateTimeFormatter getDateTimeFormatter() {
+    return dateTimeFormatter;
+  }
+
+  public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
+    this.dateTimeFormatter = dateTimeFormatter;
+  }
+
+}

--- a/src/main/java/org/opencastproject/influxdbadapter/Main.java
+++ b/src/main/java/org/opencastproject/influxdbadapter/Main.java
@@ -48,6 +48,9 @@ import io.reactivex.Flowable;
 public final class Main {
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(Main.class);
 
+  private static ConfigFile configFile;
+
+
   private Main() {
   }
 
@@ -90,7 +93,7 @@ public final class Main {
   public static void main(final String[] args) {
     // Preliminaries: command line parsing, config file parsing
     final CommandLine commandLine = CommandLine.parse(args);
-    final ConfigFile configFile = ConfigFile.readFile(commandLine.getConfigFile());
+    configFile = ConfigFile.readFile(commandLine.getConfigFile());
     configureLog(configFile);
     LOGGER.info("Logging configured");
     // Connect and configure InfluxDB
@@ -200,6 +203,14 @@ public final class Main {
       LOGGER.error("Error:", e);
     }
     System.exit(ExitStatuses.UNKNOWN);
+  }
+
+  public static ConfigFile getConfigFile() {
+    return configFile;
+  }
+
+  public static void setConfigFile(ConfigFile configFile) {
+    Main.configFile = configFile;
   }
 
 }

--- a/src/main/java/org/opencastproject/influxdbadapter/RequestLineConfiguration.java
+++ b/src/main/java/org/opencastproject/influxdbadapter/RequestLineConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.influxdbadapter;
+
+import java.util.regex.Pattern;
+
+public class RequestLineConfiguration {
+
+  public RequestLineConfiguration(Pattern pattern) {
+    super();
+    this.pattern = pattern;
+  }
+  public Pattern getPattern() {
+    return pattern;
+  }
+
+  public void setPattern(Pattern pattern) {
+    this.pattern = pattern;
+  }
+
+  private Pattern pattern;
+}

--- a/src/test/java/org/opencastproject/influxdbadapter/RequestLineTest.java
+++ b/src/test/java/org/opencastproject/influxdbadapter/RequestLineTest.java
@@ -4,7 +4,11 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.File;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 class RequestLineTest {
 
@@ -15,6 +19,14 @@ class RequestLineTest {
           "GET /mh_default_org/oaipmh-default/5a990722-6f18-4c69-ac84-4721934cb58b/c5f2ac27-0da1-4d91-952c-771905058ef5/myvideo.mp3 HTTP/1.1",
   })
   void testRequestLinePatternWithValidFileExtensions(String line) {
+    LogLine.setLogLineConfiguration(new LogLineConfiguration(
+            Pattern.compile("^(?<ip>(?:[0-9]{1,3}\\.){3}[0-9]{1,3}) - (-|[^ ]+) \\[(?<date>[^]]+)\\] \"(?<request>[^\"]*)\" (?<httpret>[0-9]+) (?<unknown1>(?:[0-9]+|-)) \"(?<referrer>[^\"]*)\" \"(?<agent>[^\"]+)\""),
+            DateTimeFormatter.ofPattern("dd/MMM/yyyy:HH:mm:ss Z")
+            .withLocale(Locale.ENGLISH)
+    ));
+    RequestLine.setRequestLineConfiguration(new RequestLineConfiguration(
+            Pattern.compile("^(?<method>[^ ]+) /(static/)?(?<organizationid>[^/]+)/(?<publicationchannel>[^/]+)/(?<episodeid>[^/]+)/(?<assetid>[^/]+)/[^/ ]+ .+$")
+    ));
     Optional<RequestLine> requestLine = RequestLine.parseLine(line);
     Assertions.assertThat(requestLine.isPresent()).isEqualTo(true);
     Assertions.assertThat(requestLine.get().getMethod()).isEqualTo("GET");
@@ -30,6 +42,14 @@ class RequestLineTest {
           "GET /my_org_edu/oaipmh-default/5a990722-6f18-4c69-ac84-4721934cb58b/c5f2ac27-0da1-4d91-952c-771905058ef5/myvideo.mp4 HTTP/1.1",
   })
   void testRequestLinePatternWithDifferentOrgIds(String line) {
+    LogLine.setLogLineConfiguration(new LogLineConfiguration(
+            Pattern.compile("^(?<ip>(?:[0-9]{1,3}\\.){3}[0-9]{1,3}) - (-|[^ ]+) \\[(?<date>[^]]+)\\] \"(?<request>[^\"]*)\" (?<httpret>[0-9]+) (?<unknown1>(?:[0-9]+|-)) \"(?<referrer>[^\"]*)\" \"(?<agent>[^\"]+)\""),
+            DateTimeFormatter.ofPattern("dd/MMM/yyyy:HH:mm:ss Z")
+            .withLocale(Locale.ENGLISH)
+    ));
+    RequestLine.setRequestLineConfiguration(new RequestLineConfiguration(
+            Pattern.compile("^(?<method>[^ ]+) /(static/)?(?<organizationid>[^/]+)/(?<publicationchannel>[^/]+)/(?<episodeid>[^/]+)/(?<assetid>[^/]+)/[^/ ]+ .+$")
+    ));
     Optional<RequestLine> requestLine = RequestLine.parseLine(line);
     Assertions.assertThat(requestLine.isPresent()).isEqualTo(true);
     Assertions.assertThat(requestLine.get().getMethod()).isEqualTo("GET");
@@ -46,6 +66,15 @@ class RequestLineTest {
           "GET /mh_default_org/oaipmh-portal/5a990722-6f18-4c69-ac84-4721934cb58b/c5f2ac27-0da1-4d91-952c-771905058ef5/myvideo.mp4 HTTP/1.1",
   })
   void testRequestLinePatternWithDifferentPublicationChannels(String line) {
+    LogLine.setLogLineConfiguration(new LogLineConfiguration(
+            Pattern.compile("^(?<ip>(?:[0-9]{1,3}\\.){3}[0-9]{1,3}) - (-|[^ ]+) \\[(?<date>[^]]+)\\] \"(?<request>[^\"]*)\" (?<httpret>[0-9]+) (?<unknown1>(?:[0-9]+|-)) \"(?<referrer>[^\"]*)\" \"(?<agent>[^\"]+)\""),
+            DateTimeFormatter.ofPattern("dd/MMM/yyyy:HH:mm:ss Z")
+            .withLocale(Locale.ENGLISH)
+    ));
+    RequestLine.setRequestLineConfiguration(new RequestLineConfiguration(
+            Pattern.compile("^(?<method>[^ ]+) /(static/)?(?<organizationid>[^/]+)/(?<publicationchannel>[^/]+)/(?<episodeid>[^/]+)/(?<assetid>[^/]+)/[^/ ]+ .+$")
+    ));
+    
     Optional<RequestLine> requestLine = RequestLine.parseLine(line);
     Assertions.assertThat(requestLine.isPresent()).isEqualTo(true);
     Assertions.assertThat(requestLine.get().getMethod()).isEqualTo("GET");


### PR DESCRIPTION
This PR Fixes #17.

The LogLine Regex, RequestLine Regex and DateTimeFormat are configurable with the opencast-influxdb-adapter.properties. Defining them is optional. Without definition they default to the previously used values.